### PR TITLE
Switch to vector road tiles with caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GeoSprint</title>
     <link rel="preconnect" href="https://unpkg.com" />
-    <link rel="preconnect" href="https://tile.openstreetmap.org" />
+    <link rel="preconnect" href="https://overpass-api.de" />
     <link
         rel="stylesheet"
         href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"


### PR DESCRIPTION
## Summary
- replace the raster OpenStreetMap base layer with vector road data fetched from the Overpass API
- cache zoom level 18 road tiles in localStorage and rehydrate them on future visits
- render the vector roads with styled GeoJSON layers and update map attribution

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d800690eb88328812b634daa7c7bd0